### PR TITLE
fix: añadidas clase InmuebleService a la cobertura de Sonar

### DIFF
--- a/Pisos/pom.xml
+++ b/Pisos/pom.xml
@@ -152,6 +152,7 @@
                     **/ReservaService.java
                     **/PagoService.java,
                     **/UsuarioService.java,
+                    **/InmuebleService.java,
                 </sonar.coverage.inclusions>
                 
                 <sonar.coverage.exclusions>


### PR DESCRIPTION
Hemos añadido la cobertura de sonar a InmuebleService y comprobado que si que funcionan todos los tes